### PR TITLE
Add a wrapMain() function for wrapping the top-level main

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ much more nicely than Dart's built-in handling!)
 
 Many programming environments have tried to make themselves suitable for shell
 scripting, but in the end they all fall far short of the ease of calling out to
-subprocesseses in Bash. As such, a principal design goal of `cli_pkg` is to
+subprocesseses in Bash. As such, a principal design goal of `cli_script` is to
 identify the core virtues that make shell scripting so appealing and reproduce
 them as closely as possible in Dart:
 

--- a/lib/cli_script.dart
+++ b/lib/cli_script.dart
@@ -66,6 +66,7 @@ void wrapMain(FutureOr<void> callback(),
     if (error is! ScriptException) {
       stderr.writeln(error);
       stderr.writeln(chain);
+      // Use the same exit code that Dart does for unhandled exceptions.
       exit(254);
     }
 


### PR DESCRIPTION
This handles errors, ensuring that nice stack traces are printed and
all output gets piped before the process exits.