### PR TITLE
Add output and lines getters on Script

### DIFF
--- a/lib/cli_script.dart
+++ b/lib/cli_script.dart
@@ -15,14 +15,12 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:async/async.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 import 'src/exception.dart';
 import 'src/extensions/byte_stream.dart';
 import 'src/extensions/line_stream.dart';
 import 'src/script.dart';
-import 'src/util.dart';
 
 export 'src/extensions/byte_list.dart';
 export 'src/extensions/byte_stream.dart';
@@ -120,6 +118,8 @@ Future<void> run(String executableAndArgs,
 /// All other arguments are forwarded to [Process.start].
 ///
 /// [the README]: https://github.com/google/dart_cli_script/blob/main/README.md#argument-parsing
+///
+/// See also [Script.output].
 Future<String> output(String executableAndArgs,
         {List<String>? args,
         String? name,
@@ -132,13 +132,12 @@ Future<String> output(String executableAndArgs,
             workingDirectory: workingDirectory,
             environment: environment,
             includeParentEnvironment: includeParentEnvironment)
-        .stdout
-        .text;
+        .output;
 
 /// Runs an executable and returns a stream of lines it prints to stdout.
 ///
 /// The returned stream emits a [ScriptException] if the executable returns a
-/// non-zero exit code (unlike [Script.stdout].
+/// non-zero exit code (unlike [Script.stdout]).
 ///
 /// The [executableAndArgs] and [args] arguments are parsed as described in [the
 /// README]. The [name] is a human-readable identifier for this script that's
@@ -146,25 +145,21 @@ Future<String> output(String executableAndArgs,
 /// All other arguments are forwarded to [Process.start].
 ///
 /// [the README]: https://github.com/google/dart_cli_script/blob/main/README.md#argument-parsing
+///
+/// See also [Script.lines].
 Stream<String> lines(String executableAndArgs,
-    {List<String>? args,
-    String? name,
-    String? workingDirectory,
-    Map<String, String>? environment,
-    bool includeParentEnvironment = true}) {
-  var script = Script(executableAndArgs,
-      args: args,
-      name: name,
-      workingDirectory: workingDirectory,
-      environment: environment,
-      includeParentEnvironment: includeParentEnvironment);
-
-  // Because the user definitely isn't able to listen to [script.done] for
-  // errors themselves, we always forward its potential [ScriptException]
-  // through the returned stream.
-  return StreamGroup.merge(
-      [script.stdout.lines, Stream.fromFuture(script.done).withoutData()]);
-}
+        {List<String>? args,
+        String? name,
+        String? workingDirectory,
+        Map<String, String>? environment,
+        bool includeParentEnvironment = true}) =>
+    Script(executableAndArgs,
+            args: args,
+            name: name,
+            workingDirectory: workingDirectory,
+            environment: environment,
+            includeParentEnvironment: includeParentEnvironment)
+        .lines;
 
 /// Runs an executable and returns whether it returns exit code 0.
 ///

--- a/lib/src/script.dart
+++ b/lib/src/script.dart
@@ -23,6 +23,7 @@ import 'package:path/path.dart' as p;
 import 'package:stack_trace/stack_trace.dart';
 
 import 'exception.dart';
+import 'extensions/byte_stream.dart';
 import 'parse_args.dart';
 import 'stdio.dart';
 import 'stdio_group.dart';
@@ -507,6 +508,20 @@ class Script {
       _outputCloser.close().catchError((_) {});
     });
   }
+
+  /// Returns this script's stdout, with trailing newlines removed.
+  ///
+  /// Like `stdout.text`, but throws a [ScriptException] if the executable
+  /// returns a non-zero exit code.
+  Future<String> get output async =>
+      (await Future.wait([stdout.text, done]))[0] as String;
+
+  /// Returns a stream of lines [this] prints to stdout.
+  ///
+  /// Like [stdout.lines], but emits a [ScriptException] if the executable
+  /// returns a non-zero exit code.
+  Stream<String> get lines =>
+      StreamGroup.merge([stdout.lines, Stream.fromFuture(done).withoutData()]);
 
   /// Returns a stream that combines both [stdout] and [stderr] the same way
   /// they'd be displayed in a terminal.

--- a/test/sub_process_test.dart
+++ b/test/sub_process_test.dart
@@ -95,6 +95,30 @@ void main() {
           })));
     });
   });
+
+  group("output", () {
+    test("returns the script's output without a trailing newline", () {
+      expect(
+          mainScript("print('hello!');").output, completion(equals("hello!")));
+    });
+
+    test("completes with a ScriptException if the script fails", () {
+      expect(mainScript("print('hello!'); exitCode = 12;").output,
+          throwsScriptException(12));
+    });
+  });
+
+  group("lines", () {
+    test("returns the script's stdout lines", () {
+      expect(mainScript(r"print('hello\nthere!');").lines,
+          emitsInOrder(["hello", "there!", emitsDone]));
+    });
+
+    test("emits a ScriptException if the script fails", () {
+      expect(mainScript("print('hello!'); exitCode = 12;").lines,
+          emitsThrough(emitsError(isScriptException(12))));
+    });
+  });
 }
 
 /// Defines tests for either stdout or for stderr.


### PR DESCRIPTION
These do the same thing as the top-level output() and lines()
functions, but for a single Script.