### PR TITLE
Add a top-level fail() function

### DIFF
--- a/lib/cli_script.dart
+++ b/lib/cli_script.dart
@@ -21,6 +21,7 @@ import 'src/exception.dart';
 import 'src/extensions/byte_stream.dart';
 import 'src/extensions/line_stream.dart';
 import 'src/script.dart';
+import 'src/stdio.dart';
 
 export 'src/extensions/byte_list.dart';
 export 'src/extensions/byte_stream.dart';
@@ -30,7 +31,7 @@ export 'src/extensions/line_stream.dart';
 export 'src/extensions/string.dart';
 export 'src/exception.dart';
 export 'src/parse_args.dart' show arg;
-export 'src/script.dart';
+export 'src/script.dart' hide scriptNameKey;
 export 'src/stdio.dart' hide stdoutKey, stderrKey;
 export 'src/temp.dart';
 
@@ -182,6 +183,22 @@ Future<bool> check(String executableAndArgs,
             environment: environment,
             includeParentEnvironment: includeParentEnvironment)
         .success;
+
+/// Prints [message] to stderr and exits the current script.
+///
+/// Within a [Script.capture] block, this throws a [ScriptException] that causes
+/// the script to exit with the given [exitCode]. Elsewhere, it exits the Dart
+/// process entirely.
+Never fail(String message, {int exitCode = 1}) {
+  currentStderr.writeln(message);
+
+  var scriptName = Zone.current[scriptNameKey];
+  if (scriptName is String) {
+    throw ScriptException(scriptName, exitCode);
+  } else {
+    exit(exitCode);
+  }
+}
 
 /// Returns a transformer that emits only the the elements of the source stream
 /// that match [regexp].

--- a/lib/src/script.dart
+++ b/lib/src/script.dart
@@ -29,6 +29,10 @@ import 'stdio.dart';
 import 'stdio_group.dart';
 import 'util.dart';
 
+/// An opaque key for the Zone value that contains the name of the current
+/// [Script].
+final scriptNameKey = #_captureName;
+
 /// A unit of execution that behaves like a process, with [stdin], [stdout], and
 /// [stderr] streams that ultimately produces an [exitCode] indicating success
 /// or failure.
@@ -199,6 +203,7 @@ class Script {
       {String? name}) {
     _checkCapture();
 
+    var scriptName = name ?? "capture";
     var childScripts = FutureGroup<void>();
     var stdinController = StreamController<List<int>>();
     var stdoutGroup = StdioGroup();
@@ -233,6 +238,7 @@ class Script {
         },
         zoneValues: {
           #_childScripts: childScripts,
+          scriptNameKey: scriptName,
           stdoutKey: stdoutGroup,
           stderrKey: stderrGroup
         },
@@ -246,7 +252,7 @@ class Script {
           }
         }));
 
-    return Script._(name ?? "capture", stdinController.sink, stdoutGroup.stream,
+    return Script._(scriptName, stdinController.sink, stdoutGroup.stream,
         stderrGroup.stream, exitCodeCompleter.future);
   }
 

--- a/test/capture_test.dart
+++ b/test/capture_test.dart
@@ -18,6 +18,7 @@ import 'dart:io';
 import 'package:test/test.dart';
 
 import 'package:cli_script/cli_script.dart';
+import 'package:cli_script/cli_script.dart' as cli_script;
 
 import 'util.dart';
 
@@ -104,6 +105,12 @@ void main() {
     expect(script.stderr.lines, emitsInOrder(["Error in capture:", "oh no"]));
   });
 
+  test("prints fail's message to stderr", () {
+    var script = Script.capture((_) => cli_script.fail("oh no"));
+    expect(script.done, throwsA(anything));
+    expect(script.stderr.lines, emitsInOrder(["oh no", emitsDone]));
+  });
+
   group("exitCode", () {
     test("completes with 0 when the capture exits successfully", () {
       expect(Script.capture((_) {}).exitCode, completion(equals(0)));
@@ -113,6 +120,13 @@ void main() {
       var script = Script.capture((_) => throw "oh no");
       script.stderr.drain();
       expect(script.exitCode, completion(equals(256)));
+    });
+
+    test("completes with the given exit code when fail() is called", () {
+      var script =
+          Script.capture((_) => cli_script.fail("oh no", exitCode: 42));
+      script.stderr.drain();
+      expect(script.exitCode, completion(equals(42)));
     });
 
     group("forwards a child script's exit code", () {


### PR DESCRIPTION
This makes it easy for script to surface fatal errors to their users.