### PR TITLE
Properly order calls to print() and writes to currentStdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.2
+
+* If the same `capture()` block both calls `print()` and writes to
+  `currentStdout`, ensure that the order of prints is preserved.
+
 ## 0.2.1
 
 * Give the stream transformers exposed by this package human-readable

--- a/lib/src/script.dart
+++ b/lib/src/script.dart
@@ -277,13 +277,7 @@ class Script {
           stderrKey: stderrGroup
         },
         zoneSpecification: ZoneSpecification(print: (_, parent, zone, line) {
-          if (!exitCodeCompleter.isCompleted) {
-            // Add a separate stream rather than using [stdoutGroup.sink] so
-            // that prints will go through even if the user has put the sink
-            // in a weird state by calling [StreamSink.close] or
-            // [StreamSink.addStream].
-            stdoutGroup.add(Stream.value(utf8.encode("$line\n")));
-          }
+          if (!exitCodeCompleter.isCompleted) stdoutGroup.writeln(line);
         }));
 
     return Script._(scriptName, stdinController.sink, stdoutGroup.stream,

--- a/lib/src/stdio_group.dart
+++ b/lib/src/stdio_group.dart
@@ -13,13 +13,17 @@
 // limitations under the License.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:async/async.dart';
 
-/// A wrapper over a [StreamGroup] that collects stdout or stderr streams and
-/// also provides an additional sink that can be used to manually add emit data
-/// to stdout/stderr.
+/// A wrapper over a [StreamGroup] that collects stdout or stderr streams.
+///
+/// This also provides an additional [sink] that can be used to manually emit
+/// data to stdout/stderr, as well as a [writeln] method that can be used for
+/// the same purpose but is unaffected by [sink] being closed or locked by
+/// [Sink.addStream].
 class StdioGroup {
   /// The inner stream group that handles all the heavy lifting of merging
   /// streams.
@@ -34,18 +38,47 @@ class StdioGroup {
   /// The controller for [sink].
   final StreamController<List<int>> _sinkController;
 
-  StdioGroup() : this._(StreamController());
+  StdioGroup() : this._(StreamController(sync: true));
 
-  StdioGroup._(this._sinkController) : sink = IOSink(_sinkController.sink) {
+  StdioGroup._(this._sinkController)
+      : sink = _StdioGroupSink(_sinkController.sink) {
     _group.add(_sinkController.stream);
   }
 
   /// See [StreamGroup.add].
   Future<void>? add(Stream<List<int>> stream) => _group.add(stream);
 
+  /// Writes [object] to [stream] like [IOSink.writeln].
+  ///
+  /// This can be called even if [sink] is closed or locked by [Sink.addStream].
+  void writeln([Object? object = ""]) => _sinkController
+    ..add(sink.encoding.encode(object.toString()))
+    ..add(sink.encoding.encode("\n"));
+
   /// See [StreamGroup.close].
   Future<void> close() {
-    sink.close();
+    _sinkController.close();
     return _group.close();
   }
+}
+
+/// A custom [IOSink] that doesn't actually close the underlying sink when it's
+/// closed.
+class _StdioGroupSink extends IOSinkBase implements IOSink {
+  /// The underlying sink.
+  final StreamSink<List<int>> _sink;
+
+  Encoding encoding = utf8;
+
+  _StdioGroupSink(this._sink);
+
+  void onAdd(List<int> data) => _sink.add(data);
+
+  void onError(Object error, [StackTrace? stackTrace]) =>
+      _sink.addError(error, stackTrace);
+
+  void onClose() {}
+
+  /// All writes are flushed automatically as soon as the stream is listened.
+  Future<void> onFlush() => Future.value();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,9 +23,3 @@ dev_dependencies:
     git: {url: git://github.com/sass/dart-sass, path: analysis}
   test: ^1.16.8
   test_descriptor: ^2.0.0
-
-dependency_overrides:
-  async:
-    git:
-      url: git://github.com/dart-lang/async
-      ref: sink-base

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_script
-version: 0.2.1
+version: 0.2.2-dev
 description:
   Write scripts that call subprocesses with the ease of shell scripting and the
   power of Dart.
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  async: ^2.7.0
+  async: ^2.8.0
   charcode: ^1.2.0
   collection: ^1.15.0
   glob: ^2.0.1
@@ -23,3 +23,9 @@ dev_dependencies:
     git: {url: git://github.com/sass/dart-sass, path: analysis}
   test: ^1.16.8
   test_descriptor: ^2.0.0
+
+dependency_overrides:
+  async:
+    git:
+      url: git://github.com/dart-lang/async
+      ref: sink-base


### PR DESCRIPTION
Relies on dart-lang/async#188