### PR TITLE
Add a BufferedScript class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.2.2
 
+* Add a `BufferedScript` class that buffers output from a Script until it's
+  explicitly released, making it easier to run multiple script in parallel
+  without having their outputs collide with one another.
+
 * If the same `capture()` block both calls `print()` and writes to
   `currentStdout`, ensure that the order of prints is preserved.
 

--- a/lib/cli_script.dart
+++ b/lib/cli_script.dart
@@ -29,6 +29,7 @@ import 'src/script.dart';
 import 'src/stdio.dart';
 import 'src/util/named_stream_transformer.dart';
 
+export 'src/buffered_script.dart';
 export 'src/cli_arguments.dart' show arg;
 export 'src/environment.dart';
 export 'src/extensions/byte_list.dart';

--- a/lib/src/buffered_script.dart
+++ b/lib/src/buffered_script.dart
@@ -1,0 +1,125 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+import 'dart:io' as io;
+import 'dart:async';
+
+import 'package:async/async.dart';
+import 'package:meta/meta.dart';
+import 'package:tuple/tuple.dart';
+
+import 'script.dart';
+import 'util/entangled_controllers.dart';
+
+/// A [Script] wrapper that suppresses all output and stores it in a buffer
+/// until [release] is called, at which point it forwards the suppressed output
+/// to [stdout] and [stderr].
+///
+/// Note that this can violate the usual guarantee that [stdout] and [stderr]
+/// will emit done events immediately after [done] completes. Instead, they'll
+/// emit done events once [done] completes *and* [release] has been called.
+///
+/// This also doesn't consider errors emitted by the underlying script unhandled
+/// by default. Those errors are still emitted as usual through [done],
+/// [success], and [exitCode], but users can wait to listen to these futures
+/// without worrying about unhandled exceptions.
+///
+/// This is useful for running multiple scripts in parallel without having their
+/// stdout and stderr streams overlap. You can wrap "background" scripts in
+/// [BufferedScript] and only [release] them once they're the only script
+/// running, or only if they fail.
+@sealed
+class BufferedScript extends Script {
+  Stream<List<int>> get stdout {
+    // Even though we use our own stdout stream, access this so that the
+    // superclass knows not to forward it to the parent context.
+    super.stdout;
+    return _stdoutCompleter.stream;
+  }
+
+  /// The completer that forwards [_stdoutBuffer] once [release] is called.
+  final _stdoutCompleter = StreamCompleter<List<int>>();
+
+  /// A buffer of the inner script's stdout.
+  ///
+  /// We need to buffer this ourselves rather than relying on the inner script's
+  /// buffer because once the inner [Script.done] completes, its stdio streams
+  /// will emit done events rather than replaying their buffers.
+  final StreamController<List<int>> _stdoutBuffer;
+
+  Stream<List<int>> get stderr {
+    // Even though we use our own stderr stream, access this so that the
+    // superclass knows not to forward it to the parent context.
+    super.stderr;
+    return _stderrCompleter.stream;
+  }
+
+  /// The completer that forwards [_stderrBuffer] once [release] is called.
+  final _stderrCompleter = StreamCompleter<List<int>>();
+
+  /// A buffer of the inner script's stderr.
+  ///
+  /// We need to buffer this ourselves rather than relying on the inner script's
+  /// buffer because once the inner [Script.done] completes, its stdio streams
+  /// will emit done events rather than replaying their buffers.
+  final StreamController<List<int>> _stderrBuffer;
+
+  /// Like [Script.capture], but all output is silently buffered until [release]
+  /// is called.
+  factory BufferedScript.capture(
+      FutureOr<void> Function(Stream<List<int>> stdin) callback,
+      {String? name}) {
+    var controllers = createEntangledControllers<List<int>>();
+    return BufferedScript._(
+        Script.capture(callback, name: name ?? "BufferedScript.capture"),
+        controllers.item1,
+        controllers.item2);
+  }
+
+  /// A helper constructor that allows [BufferedScript.capture] to pass in both
+  /// [_stdoutBuffer] and [_stderrBuffer] from a single call to
+  /// [createEntangledControllers].
+  BufferedScript._(Script script, this._stdoutBuffer, this._stderrBuffer)
+      : super.fromComponentsInternal(
+            script.name,
+            () => ScriptComponents(
+                script.stdin, Stream.empty(), Stream.empty(), script.exitCode),
+            silenceStartMessage: true) {
+    script.stdout.pipe(_stdoutBuffer);
+    script.stderr.pipe(_stderrBuffer);
+
+    // Don't consider errors unhandled by default. This allows users to wait to
+    // access [done], [success], and [exitCode] until later on, for example
+    // after another parallel script has finished executing.
+    done.catchError((_) {});
+  }
+
+  /// Emits all buffered output to [stdout] and [stderr].
+  ///
+  /// Returns a future that completes once all output has been emitted. If the
+  /// script hasn't completed yet, the returned future will block until it does.
+  /// However, unlike [done], the returned future will *not* emit an error even
+  /// if the script fails.
+  Future<void> release() => _releaseMemo.runOnce(() async {
+        _stdoutCompleter.setSourceStream(_stdoutBuffer.stream);
+        _stderrCompleter.setSourceStream(_stderrBuffer.stream);
+
+        await Future.wait([_stdoutBuffer.done, _stderrBuffer.done]);
+
+        // Give outer stdio listeners a chance to handle the IO.
+        await Future.delayed(Duration.zero);
+      });
+  AsyncMemoizer<void> _releaseMemo = AsyncMemoizer();
+}

--- a/lib/src/buffered_script.dart
+++ b/lib/src/buffered_script.dart
@@ -13,12 +13,10 @@
 // limitations under the License.
 
 import 'dart:io';
-import 'dart:io' as io;
 import 'dart:async';
 
 import 'package:async/async.dart';
 import 'package:meta/meta.dart';
-import 'package:tuple/tuple.dart';
 
 import 'script.dart';
 import 'util/entangled_controllers.dart';
@@ -119,7 +117,7 @@ class BufferedScript extends Script {
         await Future.wait([_stdoutBuffer.done, _stderrBuffer.done]);
 
         // Give outer stdio listeners a chance to handle the IO.
-        await Future.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
       });
-  AsyncMemoizer<void> _releaseMemo = AsyncMemoizer();
+  final _releaseMemo = AsyncMemoizer<void>();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_script
-version: 0.2.2-dev
+version: 0.2.2
 description:
   Write scripts that call subprocesses with the ease of shell scripting and the
   power of Dart.

--- a/test/buffered_script_test.dart
+++ b/test/buffered_script_test.dart
@@ -1,0 +1,199 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:async/async.dart';
+import 'package:test/test.dart';
+
+import 'package:cli_script/cli_script.dart';
+import 'package:cli_script/cli_script.dart' as cli_script;
+
+import 'util.dart';
+
+void main() {
+  test("doesn't forward stdout until release() is called", () async {
+    var script = BufferedScript.capture((_) async {
+      print("foo");
+      print("bar");
+      print("baz");
+    });
+
+    var stdout = StringBuffer();
+    var stdoutDone = false;
+    script.stdout.lines.listen(stdout.writeln, onDone: () => stdoutDone = true);
+
+    await pumpEventQueue();
+    expect(stdout, isEmpty);
+    expect(stdoutDone, isFalse);
+
+    await script.release();
+    expect(stdout.toString(), equals("foo\nbar\nbaz\n"));
+    expect(stdoutDone, isTrue);
+  });
+
+  test("doesn't forward stderr until release() is called", () async {
+    var script = BufferedScript.capture((_) async {
+      currentStderr.writeln("foo");
+      currentStderr.writeln("bar");
+      currentStderr.writeln("baz");
+    });
+
+    var stderr = StringBuffer();
+    var stderrDone = false;
+    script.stderr.lines.listen(stderr.writeln, onDone: () => stderrDone = true);
+
+    await pumpEventQueue();
+    expect(stderr, isEmpty);
+    expect(stderrDone, isFalse);
+
+    await script.release();
+    expect(stderr.toString(), equals("foo\nbar\nbaz\n"));
+    expect(stderrDone, isTrue);
+  });
+
+  test("replays stdout and stderr interleaved", () async {
+    var script = BufferedScript.capture((_) async {
+      print("stdout 1");
+      currentStderr.writeln("stderr 1");
+      print("stdout 2");
+      currentStderr.writeln("stderr 2");
+      print("stdout 3");
+      currentStderr.writeln("stderr 3");
+    });
+
+    expect(
+        script.combineOutput().lines,
+        emitsInOrder([
+          "stdout 1",
+          "stderr 1",
+          "stdout 2",
+          "stderr 2",
+          "stdout 3",
+          "stderr 3"
+        ]));
+
+    await pumpEventQueue();
+    await script.release();
+  });
+
+  test("forwards stdout live once release() is called", () async {
+    var script = BufferedScript.capture((stdin) async {
+      var stdinQueue = StreamQueue(stdin);
+      print("foo");
+      await stdinQueue.next;
+      print("bar");
+      await stdinQueue.next;
+      print("baz");
+      await stdinQueue.next;
+    });
+
+    var releaseCompleted = false;
+    script.release().then((_) => releaseCompleted = true);
+
+    var stdoutQueue = StreamQueue(script.stdout.lines);
+    await expectLater(stdoutQueue, emits("foo"));
+    await pumpEventQueue();
+    expect(releaseCompleted, isFalse);
+
+    script.stdin.add([0]);
+    await expectLater(stdoutQueue, emits("bar"));
+    await pumpEventQueue();
+    expect(releaseCompleted, isFalse);
+
+    script.stdin.add([0]);
+    await expectLater(stdoutQueue, emits("baz"));
+    await pumpEventQueue();
+    expect(releaseCompleted, isFalse);
+
+    script.stdin.add([0]);
+    await expectLater(stdoutQueue, emitsDone);
+    await pumpEventQueue();
+    expect(releaseCompleted, isTrue);
+  });
+
+  test("forwards stderr live once release() is called", () async {
+    var script = BufferedScript.capture((stdin) async {
+      var stdinQueue = StreamQueue(stdin);
+      currentStderr.writeln("foo");
+      await stdinQueue.next;
+      currentStderr.writeln("bar");
+      await stdinQueue.next;
+      currentStderr.writeln("baz");
+      await stdinQueue.next;
+    });
+
+    var releaseCompleted = false;
+    script.release().then((_) => releaseCompleted = true);
+
+    var stderrQueue = StreamQueue(script.stderr.lines);
+    await expectLater(stderrQueue, emits("foo"));
+    await pumpEventQueue();
+    expect(releaseCompleted, isFalse);
+
+    script.stdin.add([0]);
+    await expectLater(stderrQueue, emits("bar"));
+    await pumpEventQueue();
+    expect(releaseCompleted, isFalse);
+
+    script.stdin.add([0]);
+    await expectLater(stderrQueue, emits("baz"));
+    await pumpEventQueue();
+    expect(releaseCompleted, isFalse);
+
+    script.stdin.add([0]);
+    await expectLater(stderrQueue, emitsDone);
+    await pumpEventQueue();
+    expect(releaseCompleted, isTrue);
+  });
+
+  group("doesn't top-level", () {
+    test("a script failure", () async {
+      await BufferedScript.capture((_) {
+        throw ScriptException("script", 1);
+      }).release();
+
+      // Exception shouldn't be top-leveled even if it's unhandled.
+      await pumpEventQueue();
+    });
+
+    test("a Dart exception", () async {
+      var script = BufferedScript.capture((_) {
+        throw "oh no";
+      });
+      expect(script.stderr.lines, emitsThrough(contains("oh no")));
+
+      await script.release();
+
+      // Exception shouldn't be top-leveled even if it's unhandled.
+      await pumpEventQueue();
+    });
+  });
+
+  group("makes available through done", () {
+    test("a script failure", () async {
+      expect(
+          BufferedScript.capture((_) {
+            throw ScriptException("script", 123);
+          }).done,
+          throwsScriptException(123));
+    });
+
+    test("a Dart exception", () async {
+      expect(
+          BufferedScript.capture((_) {
+            throw "oh no";
+          }).done,
+          throwsScriptException(257));
+    });
+  });
+}


### PR DESCRIPTION
This buffers output from a Script until it's explicitly released,
making it easier to run multiple script in parallel without having
their outputs collide with one another.