### PR TITLE
Add stderrOnly to BufferedScript.capture() and silenceUntilFailure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.6
+
+* Add a `stderrOnly` parameter to `BufferedScript.capture()` and
+  `silenceUntilFailure()`. If this parameter is `true`, only the `stderr` from
+  the callbacks will be buffered or silenced, and the `stdout` will be emitted
+  normally.
+
 ## 0.2.5
 
 * Add `LineStreamExtensions.withSpans()`, which adds `SourceSpanWithContext`s to

--- a/lib/src/stdio.dart
+++ b/lib/src/stdio.dart
@@ -95,11 +95,13 @@ T silenceOutput<T>(T callback()) {
 /// forwarded to the returned script's [Script.stdout] and [Script.stderr]
 /// streams.
 ///
-/// If [when] is false, this doesn't silence any output.
+/// If [when] is false, this doesn't silence any output. If [stderrOnly] is
+/// false, this only silences stderr and passes stdout on as normal.
 Script silenceUntilFailure(
     FutureOr<void> Function(Stream<List<int>> stdin) callback,
     {String? name,
-    bool? when}) {
+    bool? when,
+    bool stderrOnly = false}) {
   // Wrap this in an additional [Script.capture] so that we can both handle the
   // failure *and* still have it be top-leveled if it's not handled by the
   // caller.
@@ -110,7 +112,7 @@ Script silenceUntilFailure(
     }
 
     var script = BufferedScript.capture((_) => callback(stdin),
-        name: name == null ? null : '$name.inner');
+        name: name == null ? null : '$name.inner', stderrOnly: stderrOnly);
 
     try {
       await script.done;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_script
-version: 0.2.5
+version: 0.2.6
 description:
   Write scripts that call subprocesses with the ease of shell scripting and the
   power of Dart.

--- a/test/buffered_script_test.dart
+++ b/test/buffered_script_test.dart
@@ -44,6 +44,16 @@ void main() {
     expect(stdoutDone, isTrue);
   });
 
+  test("forwards stdout if stderrOnly is true", () async {
+    var script = BufferedScript.capture((_) async {
+      print("foo");
+      print("bar");
+      print("baz");
+    }, stderrOnly: true);
+
+    expect(script.lines, emitsInOrder(['foo', 'bar', 'baz', emitsDone]));
+  });
+
   test("doesn't forward stderr until release() is called", () async {
     var script = BufferedScript.capture((_) async {
       currentStderr.writeln("foo");

--- a/test/stdio_test.dart
+++ b/test/stdio_test.dart
@@ -289,6 +289,14 @@ void main() {
       });
     });
 
+    test("doesn't silence stdout with stderrOnly: true", () {
+      expect(
+          Script.capture((_) {
+            silenceUntilFailure((_) => print("howdy!"), stderrOnly: true);
+          }).lines,
+          emitsInOrder([emits("howdy!"), emitsDone]));
+    });
+
     group("releases stdio when the callback fails", () {
       test("synchronously", () {
         var script = Script.capture((_) {


### PR DESCRIPTION
This parameter allows callers to silence or buffer only a script's
standard error and still handle its standard output.