### PR TITLE
Eagerly subscribe to a stream when using operator> to avoid a deadlock with Process.{stdout,stderr}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 0.3.1
+## 0.4.0
+
+* Breaking change: The `>` operator now eagerly subscribes to the stream before
+piping to the `StreamConsumer`. This fixes a bug where `Script.done` would never
+complete if either `Script.stdout` or `Script.stderr` is piped with `>` and
+its output is larger than 16 KiB.
 
 * Add `Script.outputBytes`, which works like `Script.output` but returns the raw
   bytes instead of a string representation.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_script
-version: 0.3.1-dev
+version: 0.4.0
 description:
   Write scripts that call subprocesses with the ease of shell scripting and the
   power of Dart.

--- a/test/sub_process_test.dart
+++ b/test/sub_process_test.dart
@@ -103,9 +103,27 @@ void main() {
       var controller = StreamController<List<int>>();
       script.stderr > controller.sink;
 
+      // The test must await the script's completion rather than using async
+      // test matchers to assert the same behavior observed in production code.
+      // Otherwise, this test will incorrectly pass.
       await script.done;
 
-      expect((await controller.stream.text).length, payloadSize);
+      expect(controller.stream.text, completion(hasLength(payloadSize)));
+    }, timeout: Timeout(Duration(seconds: 3)));
+
+    test("does not block with a stream transformer", () async {
+      var script = Script.fromByteTransformer(zlib.decoder);
+      script.stdin.add(zlib.encode(utf8.encode("*")));
+      var controller = StreamController<List<int>>();
+      script.stdout > controller.sink;
+      script.stdin.close();
+
+      // The test must await the script's completion rather than using async
+      // test matchers to assert the same behavior observed in production code.
+      // Otherwise, this test will incorrectly pass.
+      await script.done;
+
+      expect(controller.stream.text, completion(equals('*')));
     }, timeout: Timeout(Duration(seconds: 3)));
   });
 

--- a/test/sub_process_test.dart
+++ b/test/sub_process_test.dart
@@ -95,6 +95,18 @@ void main() {
             expect(stream.lines, emits("hello!"));
           })));
     });
+
+    test("does not block with a large chunk of data", () async {
+      var payloadSize = (1 << 16) + 1;
+      // This must be an actual script. [Script.capture] won't fail.
+      var script = mainScript('stderr.write("." * $payloadSize);');
+      var controller = StreamController<List<int>>();
+      script.stderr > controller.sink;
+
+      await script.done;
+
+      expect((await controller.stream.text).length, payloadSize);
+    }, timeout: Timeout(Duration(seconds: 3)));
   });
 
   group("subprocess environment", () {


### PR DESCRIPTION
Fixes #51 