### PR TITLE
Explicitly type Stream argument as List<int>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0
+
+* Update internal type annotations for compatibility with [dart-lang/sdk#52801].
+
+  [dart-lang/sdk#52801]: https://github.com/dart-lang/sdk/issues/52801
+
 ## 0.3.2
 
 * Declare support for Dart 3.

--- a/lib/src/extensions/line_stream.dart
+++ b/lib/src/extensions/line_stream.dart
@@ -28,7 +28,8 @@ import '../util.dart';
 /// (as commonly emitted by a shell script).
 extension LineStreamExtensions on Stream<String> {
   /// Converts this to a byte stream with newlines baked in.
-  Stream<List<int>> get bytes => map((line) => utf8.encode("$line\n"));
+  Stream<List<int>> get bytes =>
+      map<List<int>>((line) => utf8.encode("$line\n"));
 
   /// Pipes [this] into [script]'s [stdin] with newlines baked in.
   ///

--- a/lib/src/script.dart
+++ b/lib/src/script.dart
@@ -386,7 +386,7 @@ class Script {
       Script.fromByteTransformer(
           StreamTransformer.fromBind((stream) => stream.lines
               .transform(transformer)
-              .map((line) => utf8.encode("$line\n"))),
+              .map<List<int>>((line) => utf8.encode("$line\n"))),
           name: name ?? transformer.toString());
 
   /// Creates a [Script] from a function that maps strings to strings.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_script
-version: 0.3.2
+version: 1.0.0
 description:
   Write scripts that call subprocesses with the ease of shell scripting and the
   power of Dart.

--- a/test/pipe_test.dart
+++ b/test/pipe_test.dart
@@ -289,9 +289,9 @@ void main() {
   group("pipes in", () {
     group("a byte stream", () {
       test("without errors", () {
-        var pipeline =
-            Stream.fromIterable([utf8.encode("foo"), utf8.encode("bar")]) |
-                mainScript("stdin.pipe(stdout);");
+        var pipeline = Stream<List<int>>.fromIterable(
+                [utf8.encode("foo"), utf8.encode("bar")]) |
+            mainScript("stdin.pipe(stdout);");
         expect(pipeline.stdout.lines, emitsInOrder(["foobar", emitsDone]));
       });
 


### PR DESCRIPTION
A breaking change (see [0]) will make `utf8.encode()` return the more precise `Uint8List` type (instead of the current `List<int>`).

In rare circumstances this can lead to changes in behavior, mainly when code relies on type inference, a different type got inferred and the code dependend on the type not being inferred a more precise type.

Here we explicitly use `Stream<List<int>>` instead of relying on type inference (which would infer `Stream<Uint8List>` in some cases after [0]). This is necessary as the stream transformer APIs cannot work with subtypes. Example of code that fails at runtime:

```dart
  import 'dart:typed_data';
  import 'dart:convert';

  void main() {
    Stream<Uint8List> stream = Stream.fromIterable([]);
    Stream<List<int>> stream2 = stream;
    stream2.transform(utf8.decoder);
         //  ^^^ Will throw due to Utf8Decoder not being subtype of
         //      StreamTransformer<Uint8List, String>.
  }
```

[0] https://github.com/dart-lang/sdk/issues/52801