### PR TITLE
Publicly expose the `args()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0
+
+* Stable release.
+
+* Expose the `args()` function, which shell-escapes multiple arguments at once.
+
 ## 0.3.1
 
 * Add `Script.outputBytes`, which works like `Script.output` but returns the raw

--- a/lib/cli_script.dart
+++ b/lib/cli_script.dart
@@ -31,7 +31,7 @@ import 'src/stdio.dart';
 import 'src/util/named_stream_transformer.dart';
 
 export 'src/buffered_script.dart';
-export 'src/cli_arguments.dart' show arg;
+export 'src/cli_arguments.dart' show arg, args;
 export 'src/environment.dart';
 export 'src/extensions/byte_list.dart';
 export 'src/extensions/byte_stream.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_script
-version: 0.3.1
+version: 1.0.0
 description:
   Write scripts that call subprocesses with the ease of shell scripting and the
   power of Dart.


### PR DESCRIPTION
This was always intended for public use, it was just left out
accidentally.

This also makes a stable 1.0.0 release.